### PR TITLE
[FIX] ajustes em GenericInput, GenericSelect e GenericDatePicker

### DIFF
--- a/src/components/GenericDatePicker/GenericDatePicker.vue
+++ b/src/components/GenericDatePicker/GenericDatePicker.vue
@@ -33,10 +33,13 @@ const isDisabled = computed(() => props.state === "disabled");
 const hasLabelSlots = computed(() => !!slots.label);
 const hasErrorSlots = computed(() => !!slots.error);
 
+const isFirefox = /Firefox\//.test(navigator.userAgent)
+
 const datePickerState = computed(() =>
   cn(
     inputClass,
-    "w-full calendar-none",
+    "w-full",
+    isFirefox ? "" : "calendar-none",
     inputStateStyles[props.errorMessages.length > 0 ? "error" : props.state],
     attrs.class as string | undefined,
   ),
@@ -71,6 +74,7 @@ const forwarded = computed(() => {
         :disabled="isDisabled"
       />
       <svg
+        v-if="!isFirefox"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/src/components/GenericDatePicker/GenericDatePicker.vue
+++ b/src/components/GenericDatePicker/GenericDatePicker.vue
@@ -3,7 +3,7 @@ import { computed, useAttrs, useSlots } from "vue";
 import type { InputHTMLAttributes } from "vue";
 import type { datePickerState } from "../../types";
 import { cn } from "../../utils/cn";
-import { inputClass } from "../../utils/inputClass";
+import { inputClass, inputStateStyles } from "../../utils/inputClass";
 
 defineOptions({ inheritAttrs: false });
 
@@ -33,18 +33,11 @@ const isDisabled = computed(() => props.state === "disabled");
 const hasLabelSlots = computed(() => !!slots.label);
 const hasErrorSlots = computed(() => !!slots.error);
 
-const DATEPICKER_STATES: Record<datePickerState, string> = {
-  default: "ring-gray-500",
-  error: "ring-error-300 bg-error-100/10",
-  warning: "ring-warning-100",
-  disabled: "!ring-0 bg-gray-100/40",
-} as const;
-
 const datePickerState = computed(() =>
   cn(
     inputClass,
     "w-full calendar-none",
-    DATEPICKER_STATES[props.errorMessages.length > 0 ? "error" : props.state],
+    inputStateStyles[props.errorMessages.length > 0 ? "error" : props.state],
     attrs.class as string | undefined,
   ),
 );

--- a/src/components/GenericDatePicker/GenericDatePicker.vue
+++ b/src/components/GenericDatePicker/GenericDatePicker.vue
@@ -4,6 +4,7 @@ import type { InputHTMLAttributes } from "vue";
 import type { inputState } from "../../types";
 import { cn } from "../../utils/cn";
 import { inputClass, inputStateStyles } from "../../utils/inputClass";
+import GenericIcon from "../GenericIcon/GenericIcon.vue";
 
 defineOptions({ inheritAttrs: false });
 
@@ -33,7 +34,7 @@ const isDisabled = computed(() => props.state === "disabled");
 const hasLabelSlots = computed(() => !!slots.label);
 const hasErrorSlots = computed(() => !!slots.error);
 
-const isFirefox = /Firefox\//.test(navigator.userAgent)
+const isFirefox = /Firefox\//.test(navigator.userAgent);
 
 const datePickerState = computed(() =>
   cn(
@@ -73,21 +74,13 @@ const forwarded = computed(() => {
         :class="datePickerState"
         :disabled="isDisabled"
       />
-      <svg
+
+      <GenericIcon
         v-if="!isFirefox"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke-width="1.5"
-        stroke="currentColor"
-        class="absolute right-4 top-1/2 -translate-y-1/2 w-5.5 h-5.5 text-gray-500 pointer-events-none"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M6.75 3v2.25m10.5-2.25V5.25M3.75 9h16.5M4.5 6.75h15a.75.75 0 01.75.75v12a.75.75 0 01-.75.75H4.5A.75.75 0 013.75 19.5V7.5a.75.75 0 01.75-.75z"
-        />
-      </svg>
+        name="date_range"
+        class="absolute right-4 top-1/2 -translate-y-1/2 text-lg leading-tight text-gray-500 transition pointer-events-none"
+        filled
+      />
     </div>
     <!-- errors -->
     <div v-if="!hasErrorSlots && props.errorMessages.length > 0">

--- a/src/components/GenericDatePicker/GenericDatePicker.vue
+++ b/src/components/GenericDatePicker/GenericDatePicker.vue
@@ -3,6 +3,7 @@ import { computed, useAttrs, useSlots } from "vue";
 import type { InputHTMLAttributes } from "vue";
 import type { datePickerState } from "../../types";
 import { cn } from "../../utils/cn";
+import { inputClass } from "../../utils/inputClass";
 
 defineOptions({ inheritAttrs: false });
 
@@ -41,7 +42,8 @@ const DATEPICKER_STATES: Record<datePickerState, string> = {
 
 const datePickerState = computed(() =>
   cn(
-    "w-full p-4 leading-tight font-inter text-gray-600 ring hover:ring-2 rounded-lg outline-primary-400 calendar-none",
+    inputClass,
+    "w-full calendar-none",
     DATEPICKER_STATES[props.errorMessages.length > 0 ? "error" : props.state],
     attrs.class as string | undefined,
   ),

--- a/src/components/GenericDatePicker/GenericDatePicker.vue
+++ b/src/components/GenericDatePicker/GenericDatePicker.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts" generic="T extends string | undefined">
 import { computed, useAttrs, useSlots } from "vue";
 import type { InputHTMLAttributes } from "vue";
-import type { datePickerState } from "../../types";
+import type { inputState } from "../../types";
 import { cn } from "../../utils/cn";
 import { inputClass, inputStateStyles } from "../../utils/inputClass";
 
@@ -10,7 +10,7 @@ defineOptions({ inheritAttrs: false });
 type NativeDatePickerAttributes = /* @vue-ignore */ InputHTMLAttributes;
 
 type DatePickerProps = {
-  state?: datePickerState;
+  state?: inputState;
   label?: string;
   errorMessages?: string | string[];
   containerClass?: string | string[];

--- a/src/components/GenericInput/GenericInput.vue
+++ b/src/components/GenericInput/GenericInput.vue
@@ -3,7 +3,7 @@ import { computed, useAttrs, useSlots } from "vue";
 import type { InputHTMLAttributes } from "vue";
 import type { inputState } from "../../types";
 import { cn } from "../../utils/cn";
-import { inputClass } from "../../utils/inputClass";
+import { inputClass, inputStateStyles } from "../../utils/inputClass";
 
 defineOptions({ inheritAttrs: false });
 
@@ -43,18 +43,11 @@ const isSearchType = computed(() => type.value === "search");
 const hasLabelSlots = computed(() => !!slots.label);
 const hasErrorSlots = computed(() => !!slots.error);
 
-const INPUT_STATES: Record<inputState, string> = {
-  default: "ring-gray-500",
-  error: "ring-error-300 bg-error-100/10",
-  warning: "ring-warning-100",
-  disabled: "!ring-0 bg-gray-100/40",
-} as const;
-
 const inputState = computed(() =>
   cn(
     inputClass,
     "w-full",
-    INPUT_STATES[props.errorMessages.length > 0 ? "error" : props.state],
+    inputStateStyles[props.errorMessages.length > 0 ? "error" : props.state],
     attrs.class as string | undefined,
   ),
 );

--- a/src/components/GenericInput/GenericInput.vue
+++ b/src/components/GenericInput/GenericInput.vue
@@ -3,6 +3,7 @@ import { computed, useAttrs, useSlots } from "vue";
 import type { InputHTMLAttributes } from "vue";
 import type { inputState } from "../../types";
 import { cn } from "../../utils/cn";
+import { inputClass } from "../../utils/inputClass";
 
 defineOptions({ inheritAttrs: false });
 
@@ -51,7 +52,8 @@ const INPUT_STATES: Record<inputState, string> = {
 
 const inputState = computed(() =>
   cn(
-    "w-full p-4 leading-tight font-inter text-gray-600 ring hover:ring-2 rounded-lg outline-primary-400",
+    inputClass,
+    "w-full",
     INPUT_STATES[props.errorMessages.length > 0 ? "error" : props.state],
     attrs.class as string | undefined,
   ),

--- a/src/components/GenericInput/GenericInput.vue
+++ b/src/components/GenericInput/GenericInput.vue
@@ -4,6 +4,7 @@ import type { InputHTMLAttributes } from "vue";
 import type { inputState } from "../../types";
 import { cn } from "../../utils/cn";
 import { inputClass, inputStateStyles } from "../../utils/inputClass";
+import GenericIcon from "../GenericIcon/GenericIcon.vue";
 
 defineOptions({ inheritAttrs: false });
 
@@ -77,22 +78,12 @@ const forwarded = computed(() => {
         :class="inputState"
         :disabled="isDisabled"
       />
-      <svg
+      <GenericIcon
         v-if="isSearchType"
-        xmlns="http://www.w3.org/2000/svg"
-        class="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500 cursor-pointer hover:text-gray-700 transition"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        stroke-width="2"
+        name="search"
+        class="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer text-lg leading-tight text-gray-500 hover:text-gray-700 transition"
         @click="handleSearch"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z"
-        />
-      </svg>
+      />
     </div>
     <!-- errors -->
     <div v-if="!hasErrorSlots && props.errorMessages.length > 0">

--- a/src/components/GenericSelect/GenericSelect.vue
+++ b/src/components/GenericSelect/GenericSelect.vue
@@ -4,7 +4,7 @@ import { cn } from "../../utils/cn";
 import type { SelectHTMLAttributes } from "vue";
 import type { selectState } from "../../types";
 import type { selectOption } from "../../types";
-import { inputClass } from "../../utils/inputClass";
+import { inputClass, inputStateStyles } from "../../utils/inputClass";
 
 defineOptions({ inheritAttrs: false });
 
@@ -37,18 +37,11 @@ const id = computed(() => attrs.id as string | undefined);
 
 const isDisabled = computed(() => state === "disabled");
 
-const SELECT_STATES: Record<selectState, string> = {
-  default: "ring-gray-500",
-  error: "ring-error-300 bg-error-100/10",
-  warning: "ring-warning-100",
-  disabled: "ring-0 bg-gray-100/40",
-} as const;
-
 const selectState = computed(() =>
   cn(
     inputClass,
     "appearance-none w-full",
-    SELECT_STATES[errorMessages.length > 0 ? "error" : state],
+    inputStateStyles[errorMessages.length > 0 ? "error" : state],
     attrs.class as string | undefined,
   ),
 );

--- a/src/components/GenericSelect/GenericSelect.vue
+++ b/src/components/GenericSelect/GenericSelect.vue
@@ -5,6 +5,7 @@ import type { SelectHTMLAttributes } from "vue";
 import type { inputState } from "../../types";
 import type { selectOption } from "../../types";
 import { inputClass, inputStateStyles } from "../../utils/inputClass";
+import GenericIcon from "../GenericIcon/GenericIcon.vue";
 
 defineOptions({ inheritAttrs: false });
 
@@ -103,19 +104,10 @@ const forwarded = computed(() => {
       <div
         class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3"
       >
-        <svg
-          class="h-4 w-4 text-gray-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+        <GenericIcon
+          name="keyboard_arrow_down"
+          class="text-xl leading-tight text-gray-500"
+        />
       </div>
     </div>
     <!-- errors -->

--- a/src/components/GenericSelect/GenericSelect.vue
+++ b/src/components/GenericSelect/GenericSelect.vue
@@ -4,6 +4,7 @@ import { cn } from "../../utils/cn";
 import type { SelectHTMLAttributes } from "vue";
 import type { selectState } from "../../types";
 import type { selectOption } from "../../types";
+import { inputClass } from "../../utils/inputClass";
 
 defineOptions({ inheritAttrs: false });
 
@@ -45,7 +46,8 @@ const SELECT_STATES: Record<selectState, string> = {
 
 const selectState = computed(() =>
   cn(
-    "appearance-none w-full p-4 font-inter text-gray-600 ring hover:ring-2 rounded-lg outline-primary-400",
+    inputClass,
+    "appearance-none w-full",
     SELECT_STATES[errorMessages.length > 0 ? "error" : state],
     attrs.class as string | undefined,
   ),

--- a/src/components/GenericSelect/GenericSelect.vue
+++ b/src/components/GenericSelect/GenericSelect.vue
@@ -2,7 +2,7 @@
 import { computed, useAttrs } from "vue";
 import { cn } from "../../utils/cn";
 import type { SelectHTMLAttributes } from "vue";
-import type { selectState } from "../../types";
+import type { inputState } from "../../types";
 import type { selectOption } from "../../types";
 import { inputClass, inputStateStyles } from "../../utils/inputClass";
 
@@ -13,7 +13,7 @@ type NativeSelectAttributes = /* @vue-ignore */ SelectHTMLAttributes;
 type selectProps<T> = {
   options?: selectOption<T>[];
   label?: string;
-  state?: selectState;
+  state?: inputState;
   placeholder?: string;
   containerClass?: string | string[];
   errorMessages?: string | string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,10 +28,8 @@ export type buttonVariant =
   | "secondaryDanger"
   | "disabled";
 export type compactButtonVariant = "default" | "danger";
-export type datePickerState = "default" | "error" | "warning" | "disabled";
 export type snackBarVariant = "informative" | "success" | "warning" | "error";
 export type inputState = "default" | "disabled" | "error" | "warning";
-export type selectState = "default" | "error" | "warning" | "disabled";
 export type selectOption<T> = { id: string | number; value: T; label: string };
 export type StatusTagVariant =
   | "info"

--- a/src/utils/inputClass.ts
+++ b/src/utils/inputClass.ts
@@ -1,8 +1,11 @@
-export const inputClass = 'p-4 text-base font-regular font-inter leading-normal bg-white text-gray-600 rounded-lg border border-gray-500 hover:border-gray-700 focus:border-primary-500 focus:ring-2 focus:ring-blue-600/50 outline-none'
+export const inputClass =
+  "p-4 text-base font-regular font-inter leading-normal bg-white text-gray-600 rounded-lg border border-gray-500 hover:border-gray-700 focus:border-primary-500 focus:ring-2 focus:ring-blue-600/50 outline-none";
 
 export const inputStateStyles = {
   default: "",
-  error: "hover:border-red-900 border-red-800 bg-red-50 focus:border-red-800 focus:ring-red-200",
-  warning: "hover:border-orange-900 border-orange-700 bg-orange-50 focus:border-orange-700 focus:ring-orange-200",
+  error:
+    "hover:border-red-900 border-red-800 bg-red-50 focus:border-red-800 focus:ring-red-200",
+  warning:
+    "hover:border-orange-900 border-orange-700 bg-orange-50 focus:border-orange-700 focus:ring-orange-200",
   disabled: "border-gray-200 bg-gray-200 hover:border-gray-200",
-} as const
+} as const;

--- a/src/utils/inputClass.ts
+++ b/src/utils/inputClass.ts
@@ -1,1 +1,8 @@
-export const inputClass = 'p-4 text-base font-regular font-inter leading-normal bg-white text-gray-600 ring hover:ring-2 rounded-lg outline-primary-400'
+export const inputClass = 'p-4 text-base font-regular font-inter leading-normal bg-white text-gray-600 rounded-lg border border-gray-500 hover:border-gray-700 focus:border-primary-500 focus:ring-2 focus:ring-blue-600/50 outline-none'
+
+export const inputStateStyles = {
+  default: "",
+  error: "hover:border-red-900 border-red-800 bg-red-50 focus:border-red-800 focus:ring-red-200",
+  warning: "hover:border-orange-900 border-orange-700 bg-orange-50 focus:border-orange-700 focus:ring-orange-200",
+  disabled: "border-gray-200 bg-gray-200 hover:border-gray-200",
+} as const

--- a/src/utils/inputClass.ts
+++ b/src/utils/inputClass.ts
@@ -1,0 +1,1 @@
+export const inputClass = 'p-4 text-base font-regular font-inter leading-normal bg-white text-gray-600 ring hover:ring-2 rounded-lg outline-primary-400'


### PR DESCRIPTION
O tamanho do texto estava diferente entre GenericSelect e GenericInput, resultando em diferenca de altura. O icone de escolher data de GenericDatePicker tambem estava aparecendo duplicado no navegador Firefox, desabilitei as estilizacoes nesse caso. Unifiquei as estilizacoes em comuns desses tres elementos e, por fim, padronizei os icones utilizados.