### PR TITLE
[FEAT] adicionada opcao de mudar tipo de GenericButton

### DIFF
--- a/src/components/GenericButton/GenericButton.vue
+++ b/src/components/GenericButton/GenericButton.vue
@@ -47,7 +47,7 @@ const buttonVariant = computed(() =>
   ),
 );
 
-const type = computed(() => (attrs.type as NativeButtonAttributes['type']) ?? "button")
+const type = computed(() => props.type ?? "button")
 
 const forwarded = computed(() => {
   const { ...rest } = attrs;

--- a/src/components/GenericButton/GenericButton.vue
+++ b/src/components/GenericButton/GenericButton.vue
@@ -47,6 +47,8 @@ const buttonVariant = computed(() =>
   ),
 );
 
+const type = computed(() => (attrs.type as NativeButtonAttributes['type']) ?? "button")
+
 const forwarded = computed(() => {
   const { ...rest } = attrs;
   return rest;
@@ -56,7 +58,7 @@ const forwarded = computed(() => {
 <template>
   <button
     v-bind="forwarded"
-    type="button"
+    :type="type"
     :class="buttonVariant"
     :disabled="isDisabled"
     @click="onClick"


### PR DESCRIPTION
Agora o componente faz a conexao entre o atributo `type` passado para ele e seu elemento interno `button`, sendo possivel usar outros tipos como `submit`.