### PR TITLE
[FIX] alinhamento do check do GenericCheckbox

### DIFF
--- a/src/components/GenericCheckbox/GenericCheckbox.stories.ts
+++ b/src/components/GenericCheckbox/GenericCheckbox.stories.ts
@@ -136,7 +136,7 @@ const selected = ref('não')
   },
 };
 
-export const ComSlotLabel: Story = {
+export const ComSlot: Story = {
   render: () => ({
     components: { GenericCheckbox },
     data() {
@@ -146,21 +146,17 @@ export const ComSlotLabel: Story = {
     },
     template: `
       <GenericCheckbox v-model="checked" id="slot-checkbox">
-        <template #label>
-          <span class="text-sm font-bold">✔ Aceito os <em>termos</em> importantes</span>
-        </template>
+        <span class="text-sm font-bold">✔ Aceito os <em>termos</em> importantes</span>
       </GenericCheckbox>
     `,
-    name: "Com slot label",
+    name: "Com slot",
   }),
   parameters: {
     docs: {
       source: {
         code: `
 <GenericCheckbox v-model="checked" id="slot-checkbox">
-  <template #label>
-    <span class="text-sm font-bold">✔ Aceito os <em>termos</em> importantes</span>
-  </template>
+  <span class="text-sm font-bold">✔ Aceito os <em>termos</em> importantes</span>
 </GenericCheckbox>
 
 <script setup lang="ts">

--- a/src/components/GenericCheckbox/GenericCheckbox.vue
+++ b/src/components/GenericCheckbox/GenericCheckbox.vue
@@ -50,7 +50,7 @@ const forwarded = computed(() => {
   <div
     :class="
       cn(
-        'flex flex-row items-center gap-3 w-fit cursor-pointer select-none font-inter',
+        'flex flex-row items-center gap-3 w-fit font-inter',
         props.containerClass,
       )
     "

--- a/src/components/GenericCheckbox/GenericCheckbox.vue
+++ b/src/components/GenericCheckbox/GenericCheckbox.vue
@@ -29,7 +29,6 @@ const modelValue = defineModel<T>();
 const attrs = useAttrs();
 const id = computed(() => attrs.id as string | undefined);
 
-console.log(props.disabled)
 const checkboxClass = computed(() =>
   cn(
     "w-5 h-5 appearance-none rounded-xs border-1 border-gray-500 cursor-pointer  block",

--- a/src/components/GenericCheckbox/GenericCheckbox.vue
+++ b/src/components/GenericCheckbox/GenericCheckbox.vue
@@ -3,7 +3,7 @@
   setup
   generic="T extends string | number | boolean | undefined"
 >
-import { computed, useAttrs, useSlots } from "vue";
+import { computed, useAttrs } from "vue";
 import { cn } from "../../utils/cn";
 import type { InputHTMLAttributes } from "vue";
 import GenericIcon from "../GenericIcon/GenericIcon.vue";
@@ -24,11 +24,8 @@ const props = withDefaults(defineProps<CheckboxProps>(), {
 
 const modelValue = defineModel<T>();
 
-const slots = useSlots();
 const attrs = useAttrs();
 const id = computed(() => attrs.id as string | undefined);
-
-const hasLabelSlot = computed(() => !!slots.label);
 
 const checkboxClass = computed(() =>
   cn(
@@ -67,11 +64,10 @@ const forwarded = computed(() => {
       />
     </div>
 
-    <label v-if="!hasLabelSlot" :for="id">
-      {{ label }}
-    </label>
-    <label v-else-if="hasLabelSlot" :for="id">
-      <slot name="label" />
-    </label>
+    <slot>
+      <label v-if="label" :for="id">
+        {{ label }}
+      </label>
+    </slot>
   </div>
 </template>

--- a/src/components/GenericCheckbox/GenericCheckbox.vue
+++ b/src/components/GenericCheckbox/GenericCheckbox.vue
@@ -54,7 +54,7 @@ const forwarded = computed(() => {
       )
     "
   >
-    <div class="group relative">
+    <div class="group relative select-none">
       <input
         v-bind="forwarded"
         v-model="modelValue"

--- a/src/components/GenericCheckbox/GenericCheckbox.vue
+++ b/src/components/GenericCheckbox/GenericCheckbox.vue
@@ -6,6 +6,7 @@
 import { computed, useAttrs, useSlots } from "vue";
 import { cn } from "../../utils/cn";
 import type { InputHTMLAttributes } from "vue";
+import GenericIcon from "../GenericIcon/GenericIcon.vue";
 
 defineOptions({ inheritAttrs: false });
 
@@ -31,7 +32,7 @@ const hasLabelSlot = computed(() => !!slots.label);
 
 const checkboxClass = computed(() =>
   cn(
-    "w-5 h-5 appearance-none rounded-xs border-1 border-gray-500 cursor-pointer checked:border-0 checked:bg-primary-500",
+    "w-5 h-5 appearance-none rounded-xs border-1 border-gray-500 cursor-pointer checked:border-0 checked:bg-primary-500 block",
     attrs.class as string | undefined,
   ),
 );
@@ -46,17 +47,25 @@ const forwarded = computed(() => {
   <div
     :class="
       cn(
-        'group relative flex flex-row items-center gap-3 w-fit cursor-pointer select-none font-inter',
+        'flex flex-row items-center gap-3 w-fit cursor-pointer select-none font-inter',
         props.containerClass,
       )
     "
   >
-    <input
-      v-bind="forwarded"
-      v-model="modelValue"
-      type="checkbox"
-      :class="checkboxClass"
-    />
+    <div class="group relative">
+      <input
+        v-bind="forwarded"
+        v-model="modelValue"
+        type="checkbox"
+        :class="checkboxClass"
+      />
+
+      <GenericIcon
+        name="check"
+        class="pointer-events-none absolute top-[-1px] left-[-2px] hidden group-has-checked:block leading-none text-2xl text-white"
+        variant="rounded"
+      />
+    </div>
 
     <label v-if="!hasLabelSlot" :for="id">
       {{ label }}
@@ -64,19 +73,5 @@ const forwarded = computed(() => {
     <label v-else-if="hasLabelSlot" :for="id">
       <slot name="label" />
     </label>
-
-    <svg
-      pointer-events="none"
-      width="16"
-      height="13"
-      viewBox="0 0 16 13"
-      class="absolute left-1 size-3.5 hidden group-has-checked:block"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M4.75025 10.0402L1.56941 6.8594C1.21191 6.5019 0.634414 6.5019 0.276914 6.8594C-0.0805859 7.2169 -0.0805859 7.7944 0.276914 8.1519L4.10858 11.9836C4.46608 12.3411 5.04358 12.3411 5.40108 11.9836L15.0994 2.28523C15.4569 1.92773 15.4569 1.35023 15.0994 0.992734C14.7419 0.635234 14.1644 0.635234 13.8069 0.992734L4.75025 10.0402Z"
-        fill="white"
-      />
-    </svg>
   </div>
 </template>

--- a/src/components/GenericCheckbox/GenericCheckbox.vue
+++ b/src/components/GenericCheckbox/GenericCheckbox.vue
@@ -15,11 +15,13 @@ type NativeCheckboxAttributes = /* @vue-ignore */ InputHTMLAttributes;
 type CheckboxProps = {
   label?: string;
   containerClass?: string | string[];
+  disabled?: boolean;
 } & NativeCheckboxAttributes;
 
 const props = withDefaults(defineProps<CheckboxProps>(), {
   label: "",
   containerClass: () => [],
+  disabled: false,
 });
 
 const modelValue = defineModel<T>();
@@ -27,9 +29,13 @@ const modelValue = defineModel<T>();
 const attrs = useAttrs();
 const id = computed(() => attrs.id as string | undefined);
 
+console.log(props.disabled)
 const checkboxClass = computed(() =>
   cn(
-    "w-5 h-5 appearance-none rounded-xs border-1 border-gray-500 cursor-pointer checked:border-0 checked:bg-primary-500 block",
+    "w-5 h-5 appearance-none rounded-xs border-1 border-gray-500 cursor-pointer  block",
+    props.disabled
+      ? "bg-gray-100 checked:bg-gray-500"
+      : "checked:border-0 checked:bg-primary-500",
     attrs.class as string | undefined,
   ),
 );
@@ -55,6 +61,7 @@ const forwarded = computed(() => {
         v-model="modelValue"
         type="checkbox"
         :class="checkboxClass"
+        :disabled="props.disabled"
       />
 
       <GenericIcon


### PR DESCRIPTION
Atualmente a marca do checkbox fica desalinhada se o `flex-direction` do conteiner for diferente de `flex-row`. Este pr corrige isso, tambem permite omitir o elemento `label` e muda o slot do componente.