### PR TITLE
[REFACTOR] Melhoria de acessibilidade da tabela + features

### DIFF
--- a/src/components/GenericTable/GenericTable.vue
+++ b/src/components/GenericTable/GenericTable.vue
@@ -122,14 +122,6 @@ const tooltips = ref(
   Object.fromEntries(columns.map((col) => [col.key, false])),
 );
 
-const colspan = computed(() => {
-  let nColumns = columns.length
-  if (someRowsHaveActions.value || _actions.value.length > 0) {
-    nColumns = nColumns + 1
-  }
-  return nColumns
-})
-
 defineSlots<
   {
     row: (_: { rowData: T; rowIndex: number }) => unknown;
@@ -146,18 +138,18 @@ defineSlots<
 
 <template>
   <table
-    class="border border-zinc-300 rounded-lg border-separate border-spacing-0 w-full"
+    class="flex flex-col border border-zinc-300 rounded-lg"
   >
-    <td v-if="loading" :colspan>
-      <div class="flex items-center justify-center py-12">
-        <div class="text-gray-500 font-inter">Carregando...</div>
-      </div>
-    </td>
+    <tr v-if="loading">
+      <td class="flex items-center justify-center py-12 text-gray-500 font-inter">
+        Carregando...
+      </td>
+    </tr>
 
     <template v-else>
       <thead>
         <tr
-          class="bg-zinc-100 *:border-b *:border-zinc-300 gap-x-2 text-zinc-800 leading-tight"
+          class="flex *:flex-1  bg-zinc-100 border-b border-zinc-300 text-zinc-800"
         >
           <th
             v-for="column in columns" :key="column.key"
@@ -170,11 +162,11 @@ defineSlots<
 
               <GenericTooltip
                 :text="column.tooltip"
-                class="inline p-1"
+                class="inline align-middle"
                 v-model="tooltips[column.key]"
               >
                 <GenericIcon
-                  class="text-primary-500 leading-none relative top-1"
+                  class="text-primary-500 leading-none"
                   name="info"
                 />
               </GenericTooltip>
@@ -186,33 +178,31 @@ defineSlots<
           </th>
           <th
             v-if="someRowsHaveActions || _actions.length > 0"
-            class="px-5 py-4 text-left font-semibold text-base rounded-t-lg font-inter"
+            class="px-5 py-4 text-left font-semibold text-base font-inter break-normal"
           >
             Ações
           </th>
         </tr>
       </thead>
 
-      <td :colspan v-if="data.length === 0" class="border-b border-zinc-300">
-        <div
-
-          class="sticky flex items-center justify-center py-12 left-0 lg:static"
-        >
-          <span class="text-sm text-gray-500 lg:text-base">{{
-            emptyText
-          }}</span>
-        </div>
-      </td>
+      <tr
+        v-if="data.length === 0"
+        class="sticky flex items-center justify-center py-12 left-0 lg:static"
+      >
+        <td class="text-sm text-gray-500 lg:text-base">
+          {{ emptyText }}
+        </td>
+      </tr>
 
       <tbody v-else>
         <template v-for="(row, index) in _rows" :key="index">
           <slot name="row" :rowData="row" :rowIndex="index">
-            <tr class="*:border-b *:border-zinc-300">
+            <tr class="flex *:flex-1 border-b border-zinc-300">
               <slot name="cell" :rowData="row" :rowIndex="index">
                 <td
                   v-for="(col, colIndex) in columns"
                   :key="colIndex"
-                  class="text-zinc-600 leading-relaxed text-sm px-5 py-4 bg-white font-inter"
+                  class="flex items-center text-zinc-600 leading-relaxed text-sm px-5 py-4 font-inter"
                 >
                   <component
                     v-if="col.render"
@@ -247,7 +237,7 @@ defineSlots<
 
               <td
                 v-if="someRowsHaveActions"
-                class="bg-white rounded-lg px-5 py-4"
+                class="bg-white px-5 py-4"
               >
                 <div class="flex gap-x-2 items-center justify-start">
                   <template
@@ -276,7 +266,7 @@ defineSlots<
               </td>
               <td
                 v-else-if="_actions.length > 0"
-                class="bg-white rounded-lg px-5 py-4"
+                class="bg-white px-5 py-4"
               >
                 <div class="flex gap-x-2 items-center justify-start">
                   <template
@@ -311,11 +301,9 @@ defineSlots<
       <tfoot>
         <tr
           v-if="itemsPerPage && totalItems"
+          class="flex"
         >
-        <td :colspan>
-          <div
-            class="flex flex-col gap-3 items-center py-4 px-5 lg:flex-row lg:justify-between"
-          >
+          <td class="flex-1 flex flex-col gap-3 items-center py-4 px-5 lg:flex-row lg:justify-between">
             <span class="text-sm text-zinc-700 leading-tight font-inter">
               <strong>{{ itemsOfPage }}</strong> de
               <strong>{{ totalItems }}</strong> resultados
@@ -328,7 +316,6 @@ defineSlots<
               @update:model-value="updatePage"
               @change="changePage"
             />
-          </div>
           </td>
         </tr>
       </tfoot>

--- a/src/components/GenericTable/GenericTable.vue
+++ b/src/components/GenericTable/GenericTable.vue
@@ -124,7 +124,7 @@ const tooltips = ref(
 
 const colspan = computed(() => {
   let nColumns = columns.length
-  if (someRowsHaveActions || _actions.value.length > 0) {
+  if (someRowsHaveActions.value || _actions.value.length > 0) {
     nColumns = nColumns + 1
   }
   return nColumns
@@ -146,22 +146,22 @@ defineSlots<
 
 <template>
   <table
-    class="border-zinc-300 border rounded-lg w-full"
+    class="border border-zinc-300 rounded-lg border-separate border-spacing-0 w-full"
   >
-    <td :colspan v-if="loading">
+    <td v-if="loading" :colspan>
       <div class="flex items-center justify-center py-12">
         <div class="text-gray-500 font-inter">Carregando...</div>
       </div>
     </td>
 
     <template v-else>
-      <thead class="rounded-t-lg">
+      <thead>
         <tr
-          class="border-b bg-zinc-100 border-zinc-300 gap-x-2 text-zinc-800 leading-tight rounded-t-lg"
+          class="bg-zinc-100 *:border-b *:border-zinc-300 gap-x-2 text-zinc-800 leading-tight"
         >
           <th
             v-for="column in columns" :key="column.key"
-            class="px-5 py-4 text-left font-semibold text-base rounded-t-lg font-inter break-normal"
+            class="px-5 py-4 text-left font-semibold text-base font-inter break-normal"
             @mouseover="tooltips[column.key] = true"
             @mouseout="tooltips[column.key] = false"
           >
@@ -193,7 +193,7 @@ defineSlots<
         </tr>
       </thead>
 
-      <td :colspan v-if="data.length === 0">
+      <td :colspan v-if="data.length === 0" class="border-b border-zinc-300">
         <div
 
           class="sticky flex items-center justify-center py-12 left-0 lg:static"
@@ -203,15 +203,16 @@ defineSlots<
           }}</span>
         </div>
       </td>
+
       <tbody v-else>
         <template v-for="(row, index) in _rows" :key="index">
           <slot name="row" :rowData="row" :rowIndex="index">
-            <tr class="border-b border-zinc-300">
+            <tr class="*:border-b *:border-zinc-300">
               <slot name="cell" :rowData="row" :rowIndex="index">
                 <td
                   v-for="(col, colIndex) in columns"
                   :key="colIndex"
-                  class="text-zinc-600 leading-relaxed text-sm px-5 py-4 bg-white rounded-lg font-inter"
+                  class="text-zinc-600 leading-relaxed text-sm px-5 py-4 bg-white font-inter"
                 >
                   <component
                     v-if="col.render"

--- a/src/components/GenericTable/GenericTable.vue
+++ b/src/components/GenericTable/GenericTable.vue
@@ -137,6 +137,7 @@ const tooltips = ref(
 defineSlots<
   {
     row: (_: { rowData: T; rowIndex: number }) => unknown;
+    lastRow: () => unknown;
     cell: (_: { rowData: T; rowIndex: number }) => unknown;
   } & {
     [K in CellName]: (_: {
@@ -271,6 +272,9 @@ defineSlots<
             </tr>
           </slot>
         </template>
+
+        <slot name="lastRow">
+        </slot>
       </tbody>
 
       <tfoot>

--- a/src/components/GenericTable/GenericTable.vue
+++ b/src/components/GenericTable/GenericTable.vue
@@ -122,6 +122,14 @@ const tooltips = ref(
   Object.fromEntries(columns.map((col) => [col.key, false])),
 );
 
+const colspan = computed(() => {
+  let nColumns = columns.length
+  if (someRowsHaveActions || _actions.value.length > 0) {
+    nColumns = nColumns + 1
+  }
+  return nColumns
+})
+
 defineSlots<
   {
     row: (_: { rowData: T; rowIndex: number }) => unknown;
@@ -137,188 +145,192 @@ defineSlots<
 </script>
 
 <template>
-  <div class="flex flex-col border-zinc-300 border rounded-lg">
-    <!-- Loading -->
-    <div v-if="loading" class="flex items-center justify-center py-12">
-      <div class="text-gray-500 font-inter">Carregando...</div>
-    </div>
+  <table
+    class="border-zinc-300 border rounded-lg w-full"
+  >
+    <td :colspan v-if="loading">
+      <div class="flex items-center justify-center py-12">
+        <div class="text-gray-500 font-inter">Carregando...</div>
+      </div>
+    </td>
 
-    <!-- Tabela -->
-    <div v-else>
-      <div class="overflow-auto">
-        <table class="table-auto w-full">
-          <thead>
-            <tr
-              class="border-b bg-zinc-100 border-zinc-300 gap-x-2 text-zinc-800 leading-tight rounded-t-lg"
-            >
-              <template v-for="column in columns" :key="column.key">
-                <th
-                  class="px-5 py-4 text-left font-semibold text-base rounded-t-lg font-inter break-normal"
-                  @mouseover="tooltips[column.key] = true"
-                  @mouseout="tooltips[column.key] = false"
-                >
-                  <template v-if="column.tooltip">
-                    {{ column.title }}&nbsp;
+    <template v-else>
+      <thead class="rounded-t-lg">
+        <tr
+          class="border-b bg-zinc-100 border-zinc-300 gap-x-2 text-zinc-800 leading-tight rounded-t-lg"
+        >
+          <th
+            v-for="column in columns" :key="column.key"
+            class="px-5 py-4 text-left font-semibold text-base rounded-t-lg font-inter break-normal"
+            @mouseover="tooltips[column.key] = true"
+            @mouseout="tooltips[column.key] = false"
+          >
+            <template v-if="column.tooltip">
+              {{ column.title }}&nbsp;
 
-                    <GenericTooltip
-                      :text="column.tooltip"
-                      class="inline p-1"
-                      v-model="tooltips[column.key]"
-                    >
-                      <GenericIcon
-                        class="text-primary-500 leading-none relative top-1"
-                        name="info"
-                      />
-                    </GenericTooltip>
-                  </template>
-
-                  <template v-else>
-                    {{ column.title }}
-                  </template>
-                </th>
-              </template>
-              <th
-                v-if="someRowsHaveActions || _actions.length > 0"
-                class="px-5 py-4 text-left font-semibold text-base rounded-t-lg font-inter"
+              <GenericTooltip
+                :text="column.tooltip"
+                class="inline p-1"
+                v-model="tooltips[column.key]"
               >
-                Ações
-              </th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <template v-for="(row, index) in _rows" :key="index">
-              <slot name="row" :rowData="row" :rowIndex="index">
-                <tr class="border-b border-zinc-300">
-                  <slot name="cell" :rowData="row" :rowIndex="index">
-                    <td
-                      v-for="(col, colIndex) in columns"
-                      :key="colIndex"
-                      class="text-zinc-600 leading-relaxed text-sm px-5 py-4 bg-white rounded-lg font-inter"
-                    >
-                      <component
-                        v-if="col.render"
-                        :is="col.render(row[col.key], row, col.key, index)"
-                      />
-
-                      <slot
-                        v-else
-                        :name="getCellName(col)"
-                        :rowData="row"
-                        :rowIndex="index"
-                        :cellData="row[col.key]"
-                      >
-                        <component
-                          v-if="row.render"
-                          :is="
-                            (row.render as TableRender<T>)(
-                              row[col.key],
-                              row,
-                              col.key,
-                              index,
-                            )
-                          "
-                        />
-
-                        <template v-else>
-                          {{ row[col.key] }}
-                        </template>
-                      </slot>
-                    </td>
-                  </slot>
-
-                  <td
-                    v-if="someRowsHaveActions"
-                    class="bg-white rounded-lg px-5 py-4"
-                  >
-                    <div class="flex gap-x-2 items-center justify-start">
-                      <template
-                        v-for="(action, index) in row.actions"
-                        :key="index"
-                      >
-                        <GenericTooltip
-                          v-if="action.tooltip"
-                          :text="action.tooltip"
-                        >
-                          <GenericCompactButton
-                            :icon="action.icon"
-                            :variant="action.variant"
-                            @click="action.onClick(row)"
-                          />
-                        </GenericTooltip>
-
-                        <GenericCompactButton
-                          v-else
-                          :icon="action.icon"
-                          :variant="action.variant"
-                          @click="action.onClick(row)"
-                        />
-                      </template>
-                    </div>
-                  </td>
-                  <td
-                    v-else-if="_actions.length > 0"
-                    class="bg-white rounded-lg px-5 py-4"
-                  >
-                    <div class="flex gap-x-2 items-center justify-start">
-                      <template
-                        v-for="(action, index) in _actions"
-                        :key="index"
-                      >
-                        <GenericTooltip
-                          v-if="action.tooltip"
-                          :text="action.tooltip"
-                        >
-                          <GenericCompactButton
-                            :icon="action.icon"
-                            :variant="action.variant"
-                            @click="action.onClick(row)"
-                          />
-                        </GenericTooltip>
-
-                        <GenericCompactButton
-                          v-else
-                          :icon="action.icon"
-                          :variant="action.variant"
-                          @click="action.onClick(row)"
-                        />
-                      </template>
-                    </div>
-                  </td>
-                </tr>
-              </slot>
+                <GenericIcon
+                  class="text-primary-500 leading-none relative top-1"
+                  name="info"
+                />
+              </GenericTooltip>
             </template>
-          </tbody>
-        </table>
 
-        <!-- Estado vazio -->
+            <template v-else>
+              {{ column.title }}
+            </template>
+          </th>
+          <th
+            v-if="someRowsHaveActions || _actions.length > 0"
+            class="px-5 py-4 text-left font-semibold text-base rounded-t-lg font-inter"
+          >
+            Ações
+          </th>
+        </tr>
+      </thead>
+
+      <td :colspan v-if="data.length === 0">
         <div
-          v-if="data.length === 0"
+
           class="sticky flex items-center justify-center py-12 left-0 lg:static"
         >
           <span class="text-sm text-gray-500 lg:text-base">{{
             emptyText
           }}</span>
         </div>
-      </div>
+      </td>
+      <tbody v-else>
+        <template v-for="(row, index) in _rows" :key="index">
+          <slot name="row" :rowData="row" :rowIndex="index">
+            <tr class="border-b border-zinc-300">
+              <slot name="cell" :rowData="row" :rowIndex="index">
+                <td
+                  v-for="(col, colIndex) in columns"
+                  :key="colIndex"
+                  class="text-zinc-600 leading-relaxed text-sm px-5 py-4 bg-white rounded-lg font-inter"
+                >
+                  <component
+                    v-if="col.render"
+                    :is="col.render(row[col.key], row, col.key, index)"
+                  />
 
-      <div
-        v-if="itemsPerPage && totalItems"
-        class="flex flex-col gap-3 items-center py-4 px-5 lg:flex-row lg:justify-between"
-      >
-        <span class="text-sm text-zinc-700 leading-tight font-inter">
-          <a class="font-bold">{{ itemsOfPage }}</a> de
-          <a class="font-bold">{{ totalItems }}</a> resultados
-        </span>
+                  <slot
+                    v-else
+                    :name="getCellName(col)"
+                    :rowData="row"
+                    :rowIndex="index"
+                    :cellData="row[col.key]"
+                  >
+                    <component
+                      v-if="row.render"
+                      :is="
+                        (row.render as TableRender<T>)(
+                          row[col.key],
+                          row,
+                          col.key,
+                          index,
+                        )
+                      "
+                    />
 
-        <GenericPagination
-          :total-items="totalItems"
-          :items-per-page="itemsPerPage"
-          :model-value="_page"
-          @update:model-value="updatePage"
-          @change="changePage"
-        />
-      </div>
-    </div>
-  </div>
+                    <template v-else>
+                      {{ row[col.key] }}
+                    </template>
+                  </slot>
+                </td>
+              </slot>
+
+              <td
+                v-if="someRowsHaveActions"
+                class="bg-white rounded-lg px-5 py-4"
+              >
+                <div class="flex gap-x-2 items-center justify-start">
+                  <template
+                    v-for="(action, index) in row.actions"
+                    :key="index"
+                  >
+                    <GenericTooltip
+                      v-if="action.tooltip"
+                      :text="action.tooltip"
+                    >
+                      <GenericCompactButton
+                        :icon="action.icon"
+                        :variant="action.variant"
+                        @click="action.onClick(row)"
+                      />
+                    </GenericTooltip>
+
+                    <GenericCompactButton
+                      v-else
+                      :icon="action.icon"
+                      :variant="action.variant"
+                      @click="action.onClick(row)"
+                    />
+                  </template>
+                </div>
+              </td>
+              <td
+                v-else-if="_actions.length > 0"
+                class="bg-white rounded-lg px-5 py-4"
+              >
+                <div class="flex gap-x-2 items-center justify-start">
+                  <template
+                    v-for="(action, index) in _actions"
+                    :key="index"
+                  >
+                    <GenericTooltip
+                      v-if="action.tooltip"
+                      :text="action.tooltip"
+                    >
+                      <GenericCompactButton
+                        :icon="action.icon"
+                        :variant="action.variant"
+                        @click="action.onClick(row)"
+                      />
+                    </GenericTooltip>
+
+                    <GenericCompactButton
+                      v-else
+                      :icon="action.icon"
+                      :variant="action.variant"
+                      @click="action.onClick(row)"
+                    />
+                  </template>
+                </div>
+              </td>
+            </tr>
+          </slot>
+        </template>
+      </tbody>
+
+      <tfoot>
+        <tr
+          v-if="itemsPerPage && totalItems"
+        >
+        <td :colspan>
+          <div
+            class="flex flex-col gap-3 items-center py-4 px-5 lg:flex-row lg:justify-between"
+          >
+            <span class="text-sm text-zinc-700 leading-tight font-inter">
+              <strong>{{ itemsOfPage }}</strong> de
+              <strong>{{ totalItems }}</strong> resultados
+            </span>
+
+            <GenericPagination
+              :total-items="totalItems"
+              :items-per-page="itemsPerPage"
+              :model-value="_page"
+              @update:model-value="updatePage"
+              @change="changePage"
+            />
+          </div>
+          </td>
+        </tr>
+      </tfoot>
+    </template>
+  </table>
 </template>

--- a/src/components/GenericTable/GenericTable.vue
+++ b/src/components/GenericTable/GenericTable.vue
@@ -119,15 +119,24 @@ const _rows = computed(() => {
 });
 
 const _columns = computed(() => {
-  if (someRowsHaveActions.value || _actions.value.length > 0) {
-    return columns.concat([
+  const cols = columns.map(
+    c => ({
+      ...c,
+      class: "flex-1 px-5 py-4 text-left font-semibold text-base font-inter break-normal " + (c.width ?? ""),
+      cellClass: "flex-1 flex items-center text-zinc-600 leading-relaxed text-sm px-5 py-4 font-inter " + (c.width ?? "")
+    })
+  )
+  if ((someRowsHaveActions.value || _actions.value.length > 0) && !cols.find(c => c.key === "actions")) {
+    return cols.concat([
       {
         key: "actions",
         title: "Ações",
+        class: "flex-1 px-5 py-4 text-left font-semibold text-base font-inter break-normal",
+        cellClass: "flex-1 flex gap-x-2 items-center justify-start px-5 py-4"
       },
     ])
   }
-  return columns
+  return cols
 })
 
 const tooltips = ref(
@@ -162,11 +171,11 @@ defineSlots<
     <template v-else>
       <thead>
         <tr
-          class="flex *:flex-1  bg-zinc-100 border-b border-zinc-300 text-zinc-800"
+          class="flex bg-zinc-100 border-b border-zinc-300 text-zinc-800"
         >
           <th
             v-for="column in _columns" :key="column.key"
-            class="px-5 py-4 text-left font-semibold text-base font-inter break-normal"
+            :class="column.class"
             @mouseover="tooltips[column.key] = true"
             @mouseout="tooltips[column.key] = false"
           >
@@ -204,15 +213,39 @@ defineSlots<
       <tbody class="overflow-y-scroll" v-else>
         <template v-for="(row, index) in _rows" :key="index">
           <slot name="row" :rowData="row" :rowIndex="index">
-            <tr class="flex *:flex-1 border-b border-zinc-300">
+            <tr class="flex border-b border-zinc-300">
               <slot name="cell" :rowData="row" :rowIndex="index">
                 <td
-                  v-for="(col, colIndex) in columns"
+                  v-for="(col, colIndex) in _columns"
                   :key="colIndex"
-                  class="flex items-center text-zinc-600 leading-relaxed text-sm px-5 py-4 font-inter"
+                  :class="col.cellClass"
                 >
+                  <template
+                    v-if="col.key === 'actions'"
+                    v-for="(action, index) in row.actions"
+                    :key="index"
+                  >
+                    <GenericTooltip
+                      v-if="action.tooltip"
+                      :text="action.tooltip"
+                    >
+                      <GenericCompactButton
+                        :icon="action.icon"
+                        :variant="action.variant"
+                        @click="action.onClick(row)"
+                      />
+                    </GenericTooltip>
+
+                    <GenericCompactButton
+                      v-else
+                      :icon="action.icon"
+                      :variant="action.variant"
+                      @click="action.onClick(row)"
+                    />
+                  </template>
+
                   <component
-                    v-if="col.render"
+                    v-else-if="col.render"
                     :is="col.render(row[col.key], row, col.key, index)"
                   />
 
@@ -241,34 +274,6 @@ defineSlots<
                   </slot>
                 </td>
               </slot>
-
-              <td
-                v-if="someRowsHaveActions || _actions.length > 0"
-                class="flex gap-x-2 items-center justify-start px-5 py-4"
-              >
-                <template
-                  v-for="(action, index) in row.actions"
-                  :key="index"
-                >
-                  <GenericTooltip
-                    v-if="action.tooltip"
-                    :text="action.tooltip"
-                  >
-                    <GenericCompactButton
-                      :icon="action.icon"
-                      :variant="action.variant"
-                      @click="action.onClick(row)"
-                    />
-                  </GenericTooltip>
-
-                  <GenericCompactButton
-                    v-else
-                    :icon="action.icon"
-                    :variant="action.variant"
-                    @click="action.onClick(row)"
-                  />
-                </template>
-              </td>
             </tr>
           </slot>
         </template>

--- a/src/components/GenericTable/GenericTable.vue
+++ b/src/components/GenericTable/GenericTable.vue
@@ -118,6 +118,18 @@ const _rows = computed(() => {
   });
 });
 
+const _columns = computed(() => {
+  if (someRowsHaveActions.value || _actions.value.length > 0) {
+    return columns.concat([
+      {
+        key: "actions",
+        title: "Ações",
+      },
+    ])
+  }
+  return columns
+})
+
 const tooltips = ref(
   Object.fromEntries(columns.map((col) => [col.key, false])),
 );
@@ -138,7 +150,7 @@ defineSlots<
 
 <template>
   <table
-    class="flex flex-col border border-zinc-300 rounded-lg"
+    class="flex flex-col border border-zinc-300 rounded-lg overflow-x-scroll"
   >
     <tr v-if="loading">
       <td class="flex items-center justify-center py-12 text-gray-500 font-inter">
@@ -152,7 +164,7 @@ defineSlots<
           class="flex *:flex-1  bg-zinc-100 border-b border-zinc-300 text-zinc-800"
         >
           <th
-            v-for="column in columns" :key="column.key"
+            v-for="column in _columns" :key="column.key"
             class="px-5 py-4 text-left font-semibold text-base font-inter break-normal"
             @mouseover="tooltips[column.key] = true"
             @mouseout="tooltips[column.key] = false"
@@ -175,12 +187,6 @@ defineSlots<
             <template v-else>
               {{ column.title }}
             </template>
-          </th>
-          <th
-            v-if="someRowsHaveActions || _actions.length > 0"
-            class="px-5 py-4 text-left font-semibold text-base font-inter break-normal"
-          >
-            Ações
           </th>
         </tr>
       </thead>
@@ -236,62 +242,31 @@ defineSlots<
               </slot>
 
               <td
-                v-if="someRowsHaveActions"
-                class="bg-white px-5 py-4"
+                v-if="someRowsHaveActions || _actions.length > 0"
+                class="flex gap-x-2 items-center justify-start px-5 py-4"
               >
-                <div class="flex gap-x-2 items-center justify-start">
-                  <template
-                    v-for="(action, index) in row.actions"
-                    :key="index"
+                <template
+                  v-for="(action, index) in row.actions"
+                  :key="index"
+                >
+                  <GenericTooltip
+                    v-if="action.tooltip"
+                    :text="action.tooltip"
                   >
-                    <GenericTooltip
-                      v-if="action.tooltip"
-                      :text="action.tooltip"
-                    >
-                      <GenericCompactButton
-                        :icon="action.icon"
-                        :variant="action.variant"
-                        @click="action.onClick(row)"
-                      />
-                    </GenericTooltip>
-
                     <GenericCompactButton
-                      v-else
                       :icon="action.icon"
                       :variant="action.variant"
                       @click="action.onClick(row)"
                     />
-                  </template>
-                </div>
-              </td>
-              <td
-                v-else-if="_actions.length > 0"
-                class="bg-white px-5 py-4"
-              >
-                <div class="flex gap-x-2 items-center justify-start">
-                  <template
-                    v-for="(action, index) in _actions"
-                    :key="index"
-                  >
-                    <GenericTooltip
-                      v-if="action.tooltip"
-                      :text="action.tooltip"
-                    >
-                      <GenericCompactButton
-                        :icon="action.icon"
-                        :variant="action.variant"
-                        @click="action.onClick(row)"
-                      />
-                    </GenericTooltip>
+                  </GenericTooltip>
 
-                    <GenericCompactButton
-                      v-else
-                      :icon="action.icon"
-                      :variant="action.variant"
-                      @click="action.onClick(row)"
-                    />
-                  </template>
-                </div>
+                  <GenericCompactButton
+                    v-else
+                    :icon="action.icon"
+                    :variant="action.variant"
+                    @click="action.onClick(row)"
+                  />
+                </template>
               </td>
             </tr>
           </slot>

--- a/src/components/GenericTable/GenericTable.vue
+++ b/src/components/GenericTable/GenericTable.vue
@@ -201,7 +201,7 @@ defineSlots<
         </td>
       </tr>
 
-      <tbody v-else>
+      <tbody class="overflow-y-scroll" v-else>
         <template v-for="(row, index) in _rows" :key="index">
           <slot name="row" :rowData="row" :rowIndex="index">
             <tr class="flex *:flex-1 border-b border-zinc-300">

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,19 +42,19 @@ export type GenericCardProps = {
   tooltipIcon?: string;
   tooltipWidth?: string;
 } & (
-  | {
+    | {
       textVariant: CardVariant;
       captionVariant?: "default";
     }
-  | {
+    | {
       textVariant?: "default";
       captionVariant: CardVariant;
     }
-  | {
+    | {
       textVariant?: "default";
       captionVariant?: "default";
     }
-);
+  );
 export type MessageCardVariant = "default" | "warning" | "error" | "disabled";
 export type compactButtonVariant = "default" | "danger";
 export type snackBarVariant = "informative" | "success" | "warning" | "error";
@@ -103,43 +103,44 @@ export type TableHeader<T extends Record<string, unknown>> = {
   sortable?: boolean;
   tooltip?: string;
   render?: TableRender<T>;
+  width?: string;
 };
 export type TableAction<T extends Record<string, unknown>> =
   | {
-      type: "edit";
-      icon?: "edit";
-      variant?: compactButtonVariant;
-      tooltip?: string;
-      onClick: (row: T) => void;
-    }
+    type: "edit";
+    icon?: "edit";
+    variant?: compactButtonVariant;
+    tooltip?: string;
+    onClick: (row: T) => void;
+  }
   | {
-      type: "delete";
-      icon?: "delete";
-      variant?: compactButtonVariant;
-      tooltip?: string;
-      onClick: (row: T) => void;
-    }
+    type: "delete";
+    icon?: "delete";
+    variant?: compactButtonVariant;
+    tooltip?: string;
+    onClick: (row: T) => void;
+  }
   | {
-      type: "view";
-      icon?: "visibility";
-      variant?: compactButtonVariant;
-      tooltip?: string;
-      onClick: (row: T) => void;
-    }
+    type: "view";
+    icon?: "visibility";
+    variant?: compactButtonVariant;
+    tooltip?: string;
+    onClick: (row: T) => void;
+  }
   | {
-      type: "open_in_new";
-      icon?: "open_in_new";
-      variant?: compactButtonVariant;
-      tooltip?: string;
-      onClick: (row: T) => void;
-    }
+    type: "open_in_new";
+    icon?: "open_in_new";
+    variant?: compactButtonVariant;
+    tooltip?: string;
+    onClick: (row: T) => void;
+  }
   | {
-      type: "custom";
-      icon: string;
-      tooltip?: string;
-      variant?: compactButtonVariant;
-      onClick: (row: T) => void;
-    };
+    type: "custom";
+    icon: string;
+    tooltip?: string;
+    variant?: compactButtonVariant;
+    onClick: (row: T) => void;
+  };
 
 export type titleType =
   | "h1"


### PR DESCRIPTION
Este pr muda a estrutura dos elementos HTML da GenericTable para que seja melhor intepretada por leitores de tela e navegada com teclado. Tbm introduz o slot `lastRow` para facilitar a insercao de uma nova ultima linha de resumo, e a opcao `width` da coluna que permite mudar sua largura. A opcao `width` adiciona o valor ao final das classes do cabecalho e das celulas da coluna, assim deve-se usar classes Tailwind como `w-25` ou `w-[10%]` em vez de um valor como `100px` ou `15rem`.