### PR TITLE
ci: atualizar GitHub Actions depreciadas (Node.js 20 → Node.js 24)

### DIFF
--- a/.github/workflows/compo-lib.yml
+++ b/.github/workflows/compo-lib.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/generate-new-tag.yml
+++ b/.github/workflows/generate-new-tag.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout do repositório
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Gerar nova tag automaticamente
         uses: anothrNick/github-tag-action@1.67.0

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## 🚨 Atualização Obrigatória — GitHub Actions com Node.js 20 Depreciadas

### O que está acontecendo?

O GitHub anunciou a **depreciação do Node.js 20** nas GitHub Actions runners. Isso significa que todas as Actions que rodam em Node.js 20 **deixarão de funcionar corretamente** em breve.

📢 **Anúncio oficial:** https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### Prazos Importantes

| Data | O que acontece |
|------|----------------|
| **2 de Junho de 2026** | ⚠️ GitHub **forçará** todas as Actions a rodar com Node.js 24 por padrão. Actions incompatíveis podem **quebrar**. |
| **16 de Setembro de 2026** | 🚫 Node.js 20 será **completamente removido** dos runners. Nenhuma Action com Node.js 20 funcionará. |

### O que este PR faz?

Este PR atualiza as versões das GitHub Actions utilizadas nos workflows deste repositório para versões compatíveis com Node.js 24:

| Action | Versão Anterior | Nova Versão | Motivo |
|--------|----------------|-------------|--------|
| `actions/checkout` | `v2`, `v3` ou `v4` | `v6` | v2/v3/v4 usam Node.js 20 (depreciado) |
| `docker/login-action` | `v3` | `v4` | v3 usa Node.js 20 (depreciado) |
| `actions/setup-node` | `v4` | `v6` | v4 usa Node.js 20 (depreciado) |
| `actions/setup-python` | `v4` | `v6` | v4 usa Node.js 20 (depreciado) |
| `actions/setup-java` | `v3` | `v5` | v3 usa Node.js 20 (depreciado) |
| `actions/cache` | `v3` | `v5` | v3 usa Node.js 20 (depreciado) |
| `actions/upload-artifact` | `v3` | `v7` | v3 usa Node.js 20 (depreciado) |
| `actions/download-artifact` | `v3` | `v8` | v3 usa Node.js 20 (depreciado) |

### Impacto

- ✅ **Sem breaking changes** — as novas versões são retrocompatíveis
- ✅ **Sem alteração de lógica** — apenas bump de versão das Actions
- ✅ **Pipelines continuarão funcionando** normalmente após o merge
- ⚠️ **Sem este merge**, os pipelines podem **quebrar a partir de 2 de Junho de 2026**

### Como revisar?

1. Confira os arquivos alterados na aba "Files changed"
2. Verifique que as únicas mudanças são atualizações de versão (ex: `@v4` → `@v6`)
3. Se o repositório possui proteção de branch, aprove e faça merge

### Por que este PR foi criado automaticamente?

A organização `leds-conectafapes` possui **52+ repositórios** com Actions depreciadas. Para garantir que todos os pipelines continuem funcionando antes do prazo, este PR foi gerado automaticamente com as atualizações necessárias.

---

> **⏰ Ação necessária:** Por favor, revise e faça merge deste PR antes de **2 de Junho de 2026** para evitar falhas nos pipelines de CI/CD.

🤖 PR gerado automaticamente via script de atualização organizacional.